### PR TITLE
Speed up VIPS build with parallelization and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ vips-buildpack
 =========================
 
 This project is a Scalingo [buildpack](http://doc.scalingo.com/buildpacks) to
-use latest version of [libvips](www.libvips.org) (8.12.1)
+use latest version of [libvips](www.libvips.org) (8.14.2)
 alongside your app.
 
 It doesn't do anything else, you have to use it alongside another buildpack thanks to the [multi-buildpack](https://github.com/Scalingo/multi-buildpack).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ vips-buildpack
 =========================
 
 This project is a Scalingo [buildpack](http://doc.scalingo.com/buildpacks) to
-use latest version of [libvips](www.libvips.org) (8.14.2)
+use latest version of [libvips](www.libvips.org) (8.12.2)
 alongside your app.
 
 It doesn't do anything else, you have to use it alongside another buildpack thanks to the [multi-buildpack](https://github.com/Scalingo/multi-buildpack).

--- a/bin/compile
+++ b/bin/compile
@@ -2,14 +2,18 @@
 # bin/compile <build-dir> <cache-dir>
 
 BUILD_DIR=$1
+CACHE_DIR=$2
 
-mkdir $BUILD_DIR/tmp-vips
-cd $BUILD_DIR/tmp-vips
+VIPS_VERSION=8.14.2
 
-# Download VIPS
-wget "https://github.com/libvips/libvips/releases/download/v8.12.1/vips-8.12.1.tar.gz" -O vips.tar.gz
-tar -xvf vips.tar.gz
-cd vips-8.12.1
+cd $CACHE_DIR/
+
+# Download VIPS (or get from cache?)
+if [ ! -d vips-$VIPS_VERSION ]; then
+    wget "https://github.com/libvips/libvips/releases/download/v$VIPS_VERSION/vips-$VIPS_VERSION.tar.xz" -O vips-$VIPS_VERSION.tar.xz
+    tar -xvf vips-$VIPS_VERSION.tar.xz
+fi
+cd vips-$VIPS_VERSION
 
 # Compile VIPS and store in in vendor/vips
 ./configure --prefix $1/vendor/vips

--- a/bin/compile
+++ b/bin/compile
@@ -4,21 +4,42 @@
 BUILD_DIR=$1
 CACHE_DIR=$2
 
-VIPS_VERSION=8.14.2
+# VIPS 8.13 and above uses a new build system, stick to a lower version
+# (the new build system needs several dependencies, like cmake and meson)
+VIPS_VERSION=8.12.2
+source /etc/os-release
+OS_VERSION="$ID-$VERSION_ID"
+PREBUILT_VIPS_CACHE="$CACHE_DIR/$OS_VERSION/vendor/vips-$VIPS_VERSION"
 
-cd $CACHE_DIR/
+# build into a cache dir if it does not exist
+# Note that when changing Scalingo stack we should rebuild,
+# so the os release is included in the cache path as well as the version
+if [ ! -d $PREBUILT_VIPS_CACHE ]; then
+    cd $CACHE_DIR/
 
-# Download VIPS (or get from cache?)
-if [ ! -d vips-$VIPS_VERSION ]; then
-    wget "https://github.com/libvips/libvips/releases/download/v$VIPS_VERSION/vips-$VIPS_VERSION.tar.xz" -O vips-$VIPS_VERSION.tar.xz
-    tar -xvf vips-$VIPS_VERSION.tar.xz
+    # Download VIPS if not already in the cache
+    if [ ! -d "vips-$VIPS_VERSION" ]; then
+        wget "https://github.com/libvips/libvips/releases/download/v$VIPS_VERSION/vips-$VIPS_VERSION.tar.gz" -O vips-$VIPS_VERSION.tar.gz
+        tar -xvf vips-$VIPS_VERSION.tar.gz
+    fi
+    cd vips-$VIPS_VERSION
+
+    # Compile VIPS and store in in vendor/vips
+    ./configure --prefix "$PREBUILT_VIPS_CACHE"
+    make -j$(nproc)
+    make install
+
+    if [ $? -ne 0 ]; then
+        cd ..
+        echo "Install failed, removing cache dirs"
+        rm -R vips-$VIPS_VERSION
+        rm -R "$PREBUILT_VIPS_CACHE"
+        exit 1
+    fi
 fi
-cd vips-$VIPS_VERSION
-
-# Compile VIPS and store in in vendor/vips
-./configure --prefix $1/vendor/vips
-make
-make install
+echo "Copying vips from cache dir into build dir"
+mkdir -p "$BUILD_DIR/vendor"
+cp -R "$PREBUILT_VIPS_CACHE" "$BUILD_DIR/vendor/vips"
 
 # Preparing runtime environment
 mkdir -p $BUILD_DIR/.profile.d


### PR DESCRIPTION
Reduces build time on my app from ~9 minutes to 5 (first build) and further to 4 on subsequent builds.